### PR TITLE
fix: notification api

### DIFF
--- a/app/src/main/java/com/example/gravit/api/ApiService.kt
+++ b/app/src/main/java/com/example/gravit/api/ApiService.kt
@@ -504,21 +504,19 @@ data class InquiryAnswer(
     val answeredAt: String
 )
 //인앱알림
-data class Notifications(
-    val hasNextPage: Boolean,
-    val contents: List<NotificationData>
-)
 
-data class NotificationData(
+data class Notifications(
     val id: Long,
     val type: String,
-    val message: String,
+    val message: String?,
+    val subText: String?,
     val actionType: String,
     val targetId: Long?,
+    val congratulated: Boolean?,
     val read: Boolean,
     val createdAt: String,
     val timeAgo: String,
-    val actor: ActorData
+    val actor: ActorData?
 )
 data class ActorData(
     val profileId: Long,
@@ -820,7 +818,6 @@ interface ApiService {
     @GET("api/v1/notifications")
     suspend fun getNotifications(
         @Header("Authorization") auth: String,
-        @Query("page") page: Int
-    ) : Notifications
+    ) : List<Notifications>
 }
 

--- a/app/src/main/java/com/example/gravit/main/User/Notice/Notification.kt
+++ b/app/src/main/java/com/example/gravit/main/User/Notice/Notification.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,6 +36,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -54,15 +54,13 @@ import com.inuappcenter.gravit.main.User.UserScreenVM
 import com.inuappcenter.gravit.main.User.UserVMFactory
 import com.inuappcenter.gravit.ui.theme.ProfilePalette
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun Notice2(
+fun Notification(
     navController: NavController,
 ){
     val date = LocalDate.now()
@@ -77,20 +75,27 @@ fun Notice2(
     val congratulateVM: UserScreenVM = viewModel(factory = UserVMFactory(RetrofitInstance.api, context))
     val congratulateUi by congratulateVM.stateCongratulate.collectAsState()
 
+    val actionUi by notificationVM.stateAction.collectAsState()
 
     var navigated by remember { mutableStateOf(false) }
     var showSnackBar by remember { mutableStateOf(false) }
     var snackBarText by remember { mutableStateOf("") }
-    val isLoading = notificationUi == NotificationVM.UiState.Loading
+    val isLoading = notificationUi == NotificationVM.UiState.Loading ||
+                    congratulateUi == UserScreenVM.CongratulateUiState.Loading ||
+                    actionUi == NotificationVM.ActionUiState.Loading
+
+    val isSessionExpired = notificationUi == NotificationVM.UiState.SessionExpired ||
+            congratulateUi == UserScreenVM.CongratulateUiState.SessionExpired ||
+            actionUi == NotificationVM.ActionUiState.SessionExpired
+
     LaunchedEffect(Unit) {
         notificationVM.load()
     }
 
-    LaunchedEffect(notificationUi) {
+    LaunchedEffect(isSessionExpired, notificationUi) {
         if (navigated) return@LaunchedEffect
-
-        when (notificationUi) {
-            NotificationVM.UiState.SessionExpired -> {
+        when {
+            isSessionExpired -> {
                 navigated = true
                 navController.navigate("error/401") {
                     popUpTo(
@@ -101,8 +106,7 @@ fun Notice2(
                     launchSingleTop = true
                 }
             }
-
-            NotificationVM.UiState.NotFound -> {
+            notificationUi == NotificationVM.UiState.NotFound -> {
                 navigated = true
                 navController.navigate("error/404"){
                     popUpTo(
@@ -116,23 +120,9 @@ fun Notice2(
             else -> Unit
         }
     }
-    val listState = rememberLazyListState()
 
-    LaunchedEffect(listState) {
-        snapshotFlow {
-            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
-            val total = listState.layoutInfo.totalItemsCount
-            if (last != null) last to total else null
-        }
-            .filterNotNull()
-            .distinctUntilChanged()
-            .collect { (lastVisible, total) ->
-                if (lastVisible >= total - 3) {
-                    notificationVM.loadMore()
-                }
-            }
-    }
-    val notification = (notificationUi as? NotificationVM.UiState.Success)?.data
+    val listState = rememberLazyListState()
+    val notifications = (notificationUi as? NotificationVM.UiState.Success)?.data
 
     Box (
         modifier = Modifier.fillMaxSize()
@@ -159,176 +149,172 @@ fun Notice2(
                     bottom = 16.dp
                 )
             )
-            if(notification?.contents.isNullOrEmpty()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        buildAnnotatedString {
-                            withStyle(
-                                AppTypography.Headline1.toSpanStyle() //임시 스타일
-                                    .copy(color = AppColor.text2)
-                            ) {
-                                append("알림이 없어요.")
-                            }
-                            append("\n")
-                            withStyle(
-                                AppTypography.Label1.toSpanStyle() //임시 스타일
-                                    .copy(color = AppColor.text3w)
-                            ) {
-                                append("궁금한 점이 있다면 문의하기를 통해 남겨주세요.")
-                            }
-                        },
-                        textAlign = TextAlign.Center
-                    )
-                }
-            }else {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(AppColor.bg2),
-                ) {
-                    items(notification.contents) { notification ->
-                        Box(
+            when (notificationUi){
+                is NotificationVM.UiState.Success ->{
+                    if(notifications.isNullOrEmpty()){
+                        EmptyUi()
+                    }else{
+                        LazyColumn(
+                            state = listState,
                             modifier = Modifier
-                                .padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
-                                .fillMaxWidth()
-                                .height(114.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                                .background(AppColor.bg0)
-                                .border(
-                                    1.dp,
-                                    shape = RoundedCornerShape(8.dp),
-                                    color = AppColor.divider1
-                                )
-                                .padding(16.dp)
+                                .fillMaxSize()
+                                .background(AppColor.bg2),
                         ) {
-                            Column(
-                            ) {
-                                if (notification.actionType == "FOLLOW_BACK" || notification.actionType == "UNFOLLOW") {
-                                    Row() {
-                                        Box(
-                                            modifier = Modifier
-                                                .size(38.dp)
-                                                .clip(CircleShape)
-                                                .background(ProfilePalette.idToColor(notification.actor.profileImgNumber)),
-                                            contentAlignment = Alignment.Center
-                                        ) {
-                                            Image(
-                                                painter = painterResource(id = R.drawable.profile_logo),
-                                                contentDescription = "profile logo",
-                                                modifier = Modifier.size(18.dp, 20.dp)
-                                            )
-                                        }
-                                        Spacer(Modifier.width(12.dp))
-                                        Column() {
-                                            Row(
-                                                verticalAlignment = Alignment.CenterVertically
+                            items(notifications) { notification ->
+                                Box(
+                                    modifier = Modifier
+                                        .padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+                                        .fillMaxWidth()
+                                        .height(114.dp)
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .background(AppColor.bg0)
+                                        .border(
+                                            1.dp,
+                                            shape = RoundedCornerShape(8.dp),
+                                            color = AppColor.divider1
+                                        )
+                                        .padding(16.dp)
+                                ) {
+                                    Column(
+                                    ) {
+                                        if (notification.type == "FOLLOW" || notification.actionType == "UNFOLLOW") {
+                                            Row() {
+                                                Box(
+                                                    modifier = Modifier
+                                                        .size(38.dp)
+                                                        .clip(CircleShape)
+                                                        .background(ProfilePalette.idToColor(
+                                                            notification.actor?.profileImgNumber ?: 1
+                                                        )),
+                                                    contentAlignment = Alignment.Center
+                                                ) {
+                                                    Image(
+                                                        painter = painterResource(id = R.drawable.profile_logo),
+                                                        contentDescription = "profile logo",
+                                                        modifier = Modifier.size(18.dp, 20.dp)
+                                                    )
+                                                }
+                                                Spacer(Modifier.width(12.dp))
+                                                Column() {
+                                                    Row(
+                                                        verticalAlignment = Alignment.CenterVertically
+                                                    ) {
+                                                        Text(
+                                                            text = notification.actor?.nickname ?: "",
+                                                            style = AppTypography.Label1,
+                                                            color = AppColor.text1
+                                                        )
+                                                        Spacer(Modifier.width(4.dp))
+                                                        Text(
+                                                            text = notification.timeAgo,
+                                                            style = AppTypography.Caption1,
+                                                            color = AppColor.text4
+                                                        )
+                                                    }
+                                                    Spacer(Modifier.height(4.dp))
+                                                    notification.message?.let {
+                                                        Text(
+                                                            text = it,
+                                                            style = AppTypography.Label2,
+                                                            maxLines = 2,
+                                                            color = AppColor.text3
+                                                        )
+                                                    }
+                                                }
+                                            }
+                                        } else {
+                                            Box(
+                                                modifier = Modifier.fillMaxWidth()
                                             ) {
-                                                Text(
-                                                    text = notification.actor.nickname,
-                                                    style = AppTypography.Label1,
-                                                    color = AppColor.text1
-                                                )
-                                                Spacer(Modifier.width(4.dp))
+                                                notification.message?.let {
+                                                    Text(
+                                                        text = it,
+                                                        style = AppTypography.Label1,
+                                                        color = AppColor.text1,
+                                                        maxLines = 2,
+                                                        overflow = TextOverflow.Ellipsis,
+                                                        modifier = Modifier
+                                                            .fillMaxWidth()
+                                                            .padding(end = 43.dp)
+                                                    )
+                                                }
+
                                                 Text(
                                                     text = notification.timeAgo,
                                                     style = AppTypography.Caption1,
-                                                    color = AppColor.text4
+                                                    color = AppColor.text4,
+                                                    maxLines = 1,
+                                                    modifier = Modifier.align(Alignment.TopEnd)
                                                 )
                                             }
-                                            Spacer(Modifier.height(4.dp))
-                                            Text(
-                                                text = notification.message,
+                                        }
+                                        if (notification.actionType != "NONE") {
+                                            Spacer(Modifier.weight(1f))
+                                            InlineButton(
+                                                text =
+                                                    when (notification.actionType) {
+                                                        "FOLLOW_BACK" -> "맞팔로우"
+                                                        "GO_TO_LEARNING" -> "학습하러 가기"
+                                                        "GO_TO_NOTICE" -> "공지사항 바로가기"
+                                                        "UNFOLLOW" -> "팔로우 취소"
+                                                        "CONGRATULATE" -> "축하하기"
+                                                        "GO_TO_INQUIRY" -> "문의사항 바로가기"
+                                                        else -> ""
+                                                    },
+                                                onClick = {
+                                                    when (notification.actionType) {
+                                                        "FOLLOW_BACK" -> {
+                                                            notificationVM.toggleFollow(
+                                                                notification.targetId ?: 0,
+                                                                notification.actionType
+                                                            )
+                                                        }
+
+                                                        "GO_TO_LEARNING" -> {
+                                                            if (notification.targetId == null)
+                                                                navController.navigate("chapter")
+                                                            else navController.navigate("lessonList/${notification.targetId}")
+                                                        }
+
+                                                        "GO_TO_NOTICE" -> {
+                                                            navController.navigate("user/notice/detail/${notification.targetId}")
+                                                        }
+
+                                                        "UNFOLLOW" -> {
+                                                            notificationVM.toggleFollow(
+                                                                notification.targetId ?: 0,
+                                                                notification.actionType
+                                                            )
+                                                        }
+
+                                                        "CONGRATULATE" -> {
+                                                            congratulateVM.congratulate(
+                                                                notification.targetId ?: 0
+                                                            )
+                                                        }
+
+                                                        "GO_TO_INQUIRY" -> {
+                                                            navController.navigate("inquiry")
+                                                        }
+
+                                                        else -> Unit
+                                                    }
+                                                },
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .height(32.dp),
                                                 style = AppTypography.Label2,
-                                                color = AppColor.text3
+                                                color = if (notification.actionType == "UNFOLLOW") AppColor.CTA else AppColor.CTA_text,
+                                                state = if (notification.actionType == "UNFOLLOW") InlineButtonState.Stroke_Color else InlineButtonState.Default
                                             )
                                         }
                                     }
-                                } else {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Text(
-                                            text = notification.message,
-                                            style = AppTypography.Label1,
-                                            color = AppColor.text1
-                                        )
-                                        Spacer(Modifier.width(4.dp))
-                                        Text(
-                                            text = notification.timeAgo,
-                                            style = AppTypography.Caption1,
-                                            color = AppColor.text4
-                                        )
-                                    }
-                                }
-                                Spacer(Modifier.weight(1f))
-                                if (notification.actionType != "NONE") {
-                                    InlineButton(
-                                        text =
-                                            when (notification.actionType) {
-                                                "FOLLOW_BACK" -> "맞팔로우"
-                                                "GO_TO_LEARNING" -> "학습하러 가기"
-                                                "GO_TO_NOTICE" -> "공지사항 바로가기"
-                                                "UNFOLLOW" -> "팔로우 취소"
-                                                "CONGRATULATE" -> "축하하기"
-                                                "GO_TO_INQUIRY" -> "문의사항 바로가기"
-                                                else -> ""
-                                            },
-                                        onClick = {
-                                            when (notification.actionType) {
-                                                "FOLLOW_BACK" -> {
-                                                    notificationVM.toggleFollow(
-                                                        notification.targetId ?: 0,
-                                                        notification.actionType
-                                                    )
-                                                }
-
-                                                "GO_TO_LEARNING" -> {
-                                                    if (notification.targetId == null)
-                                                        navController.navigate("chapter")
-                                                    else navController.navigate("")
-                                                }
-
-                                                "GO_TO_NOTICE" -> {
-                                                    navController.navigate("")
-                                                }
-
-                                                "UNFOLLOW" -> {
-                                                    notificationVM.toggleFollow(
-                                                        notification.targetId ?: 0,
-                                                        notification.actionType
-                                                    )
-                                                }
-
-                                                "CONGRATULATE" -> {
-                                                    congratulateVM.congratulate(
-                                                        notification.targetId ?: 0
-                                                    )
-                                                }
-
-                                                "GO_TO_INQUIRY" -> {
-                                                    navController.navigate("")
-                                                }
-
-                                                else -> Unit
-                                            }
-                                        },
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(32.dp),
-                                        style = AppTypography.Label2,
-                                        color = if (notification.actionType == "UNFOLLOW") AppColor.CTA else AppColor.CTA_text,
-                                        state = if (notification.actionType == "UNFOLLOW") InlineButtonState.Stroke_Color else InlineButtonState.Default
-                                    )
                                 }
                             }
                         }
                     }
                 }
+                else -> Unit
             }
         }
         if(isLoading){
@@ -352,5 +338,34 @@ fun Notice2(
                 showSnackBar = false
             }
         }
+    }
+}
+
+@Composable
+fun EmptyUi(){
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = buildAnnotatedString {
+                withStyle(
+                    AppTypography.Headline1.toSpanStyle()
+                        .copy(color = AppColor.text2)
+                ) {
+                    append("알림이 없어요.")
+                }
+
+                append("\n")
+
+                withStyle(
+                    AppTypography.Label1.toSpanStyle()
+                        .copy(color = AppColor.text3w)
+                ) {
+                    append("궁금한 점이 있다면 문의하기를 통해 남겨주세요.")
+                }
+            },
+            textAlign = TextAlign.Center
+        )
     }
 }

--- a/app/src/main/java/com/example/gravit/main/User/Notice/NotificationVM.kt
+++ b/app/src/main/java/com/example/gravit/main/User/Notice/NotificationVM.kt
@@ -1,6 +1,7 @@
 package com.example.gravit.main.User.Notice
 
 import android.content.Context
+import android.system.Os.access
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -21,7 +22,7 @@ class NotificationVM(
     sealed interface UiState{
         data object Idle: UiState
         data object Loading : UiState
-        data class Success(val data: Notifications) : UiState
+        data class Success(val data: List<Notifications>) : UiState
         data object Failed : UiState
         data object SessionExpired : UiState
         data object NotFound : UiState
@@ -30,72 +31,27 @@ class NotificationVM(
     private val _state = MutableStateFlow<UiState>(UiState.Idle)
     val state = _state.asStateFlow()
 
-    private var page = 0
-    private var hasNext = true
-    private var isLoading = false
-
     fun load() = viewModelScope.launch {
-        if(isLoading) return@launch
         _state.value = UiState.Loading
-        isLoading = true
-        try {
-            val session = AuthPrefs.load(appContext)
-            if(session == null){
-                AuthPrefs.clear(appContext)
-                _state.value = UiState.SessionExpired
-                return@launch
-            }
-            runCatching {
-                api.getNotifications("Bearer ${session.accessToken}", 0)
-            }.onSuccess { res ->
-                page = 0
-                hasNext = res.hasNextPage
-                _state.value = UiState.Success(res)
-            }.onFailure{ e ->
-                handleApiFailure(
-                    e = e,
-                    appContext = appContext,
-                    onStateChange = {_state.value = it },
-                    unauthorizedState = UiState.SessionExpired,
-                    notFoundState = UiState.NotFound,
-                    failedState = UiState.Failed
-                )
-            }
-        } finally {
-            isLoading = false
-        }
-    }
-
-    fun loadMore() = viewModelScope.launch {
-        if(isLoading || !hasNext) return@launch
-        val currentState = _state.value as? UiState.Success ?: return@launch
-
         val session = AuthPrefs.load(appContext)
         if(session == null){
             AuthPrefs.clear(appContext)
             _state.value = UiState.SessionExpired
             return@launch
         }
-        isLoading = true
-        try{
-            runCatching {
-                api.getNotifications("Bearer ${session.accessToken}", page+1)
-            }.onSuccess { next ->
-                page += 1
-                hasNext = next.hasNextPage
-                _state.value = currentState.copy(
-                    data = currentState.data.copy(
-                        hasNextPage = next.hasNextPage,
-                        contents = currentState.data.contents + next.contents
-                    )
-                )
-            }.onFailure {
-                _state.value = currentState.copy(
-                    data = currentState.data.copy()
-                )
-            }
-        } finally {
-            isLoading = false
+        runCatching {
+            api.getNotifications("Bearer ${session.accessToken}")
+        }.onSuccess { res ->
+            _state.value = UiState.Success(res)
+        }.onFailure{ e ->
+            handleApiFailure(
+                e = e,
+                appContext = appContext,
+                onStateChange = {_state.value = it },
+                unauthorizedState = UiState.SessionExpired,
+                notFoundState = UiState.NotFound,
+                failedState = UiState.Failed
+            )
         }
     }
 

--- a/app/src/main/java/com/example/gravit/navigation/MainScreen.kt
+++ b/app/src/main/java/com/example/gravit/navigation/MainScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import com.example.gravit.main.User.Inquiry.Inquiry
-import com.example.gravit.main.User.Notice.Notice2
+import com.example.gravit.main.User.Notice.Notification
 import com.inuappcenter.gravit.main.User.MyPage
 
 
@@ -207,7 +207,7 @@ fun MainScreen(rootNavController: NavController) {
 
                 // notice
                 composable("user/notice") { Notice(innerNavController) }
-                composable("user/notice2") { Notice2(innerNavController) }
+                composable("user/notice2") { Notification(innerNavController) }
                 composable(
                     route = "user/notice/detail/{noticeId}",
                     arguments = listOf(


### PR DESCRIPTION
## 작업 내용
api 변경사항 반영
- DTO에서 hasNextPage, contents를 제거하고 API 응답 타입을 List<NotificationData>로 변경(NotificationData명을 Notification으로 수정)
- 서버의 페이지네이션 제거에 맞춰 ViewModel의 기존 페이지네이션 로직 제거

UI 변경사항
- SessionExpired 상태를 처리하는 LaunchedEffect 추가 ("error/401"로 이동)
- isLoading에 CongratulateUiState와 ActionUiState 추가
- 알림 데이터가 없을 때 표시할 EmptyUi 구현

기타
- 기존 Notice 함수와의 혼동을 방지하기 위해 함수명을 Notice2에서 Notification으로 변경

## 관련 이슈

close #이슈번호
