### PR TITLE
fix: notification navigate

### DIFF
--- a/app/src/main/java/com/example/gravit/main/Home/HomeScreen.kt
+++ b/app/src/main/java/com/example/gravit/main/Home/HomeScreen.kt
@@ -616,7 +616,7 @@ fun HomeUI(
 
                         onUnitClick = { unit ->
                             navController.navigate(
-                                "lessonList/${unit.unitId}/${unit.title}"
+                                "lessonList/${unit.unitId}"
                             ) {
                                 launchSingleTop = true
                             }

--- a/app/src/main/java/com/example/gravit/main/Study/Lesson/LessonList.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Lesson/LessonList.kt
@@ -94,8 +94,7 @@ import kotlin.math.abs
 fun LessonList(
     unitId: Int,
     onSessionExpired: () -> Unit,
-    navController: NavController,
-    unitTitle: String
+    navController: NavController
 ) {
     val context = LocalContext.current
     val vm: LessonListVM = viewModel(factory = LessonListVMFactory(RetrofitInstance.api, context))
@@ -159,7 +158,7 @@ fun LessonList(
                 lessonSummaries = lessonSummaries,
                 bookmarkAccessible = bookmarkAccessible,
                 wrongAnsweredNoteAccessible = wrongAnsweredNoteAccessible,
-                unitTitle = unitTitle
+                unitTitle = s.unitSummaryResponse.title
             )
         }
         else -> Unit

--- a/app/src/main/java/com/example/gravit/main/Study/Problem/ProblemUI.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Problem/ProblemUI.kt
@@ -133,8 +133,8 @@ fun ProblemUI(
         if (type == "normal") {
             showSheet = true
         } else {
-            navController.navigate("lessonList/$unitId/$unitTitle") {
-                popUpTo("lessonList/$unitId/$unitTitle") { inclusive = true }
+            navController.navigate("lessonList/$unitId") {
+                popUpTo("lessonList/$unitId") { inclusive = true }
                 launchSingleTop = true
             }
         }
@@ -179,8 +179,8 @@ fun ProblemUI(
                                 if (type == "normal") {
                                     showSheet = true
                                 } else {
-                                    navController.navigate("lessonList/$unitId/$unitTitle") {
-                                        popUpTo("lessonList/$unitId/$unitTitle") { inclusive = true }
+                                    navController.navigate("lessonList/$unitId") {
+                                        popUpTo("lessonList/$unitId") { inclusive = true }
                                         launchSingleTop = true
                                     }
                                 }
@@ -392,8 +392,8 @@ fun ProblemUI(
                 },
                 onCancel = {
                     showSheet = false
-                    navController.navigate("lessonList/$unitId/$unitTitle") {
-                        popUpTo("lessonList/$unitId/$unitTitle") { inclusive = true }
+                    navController.navigate("lessonList/$unitId") {
+                        popUpTo("lessonList/$unitId") { inclusive = true }
                         launchSingleTop = true
                     }
                 }

--- a/app/src/main/java/com/example/gravit/main/Study/Unit/UnitList.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Unit/UnitList.kt
@@ -142,7 +142,8 @@ fun UnitList(
             UnitListContent(
                 chapterTitle = data.chapterSummaryResponse.title,
                 units = units,
-                navController = navController
+                navController = navController,
+                chapterId = chapterId
             )
         }
     }
@@ -152,7 +153,8 @@ fun UnitList(
 private fun UnitListContent(
     chapterTitle: String,
     units: List<UnitUi>,
-    navController: NavController
+    navController: NavController,
+    chapterId: Int
 ) {
     Box(
         modifier = Modifier.fillMaxSize()
@@ -193,7 +195,7 @@ private fun UnitListContent(
 
                                 if (!popped) {
                                     navController.navigate("chapter") {
-                                        popUpTo("unit/{chapterId}") {
+                                        popUpTo("unit/$chapterId") {
                                             inclusive = true
                                         }
                                         launchSingleTop = true
@@ -274,7 +276,7 @@ private fun UnitItemBox(
             .clip(RoundedCornerShape(8.dp))
             .border(width = 1.dp, color = Color(0xFF8B69FF), RoundedCornerShape(8.dp))
             .clickable {
-                navController.navigate("lessonList/${unit.unitId}/${unit.title}")
+                navController.navigate("lessonList/${unit.unitId}")
             }
     ) {
         Image(

--- a/app/src/main/java/com/example/gravit/main/User/MyPage.kt
+++ b/app/src/main/java/com/example/gravit/main/User/MyPage.kt
@@ -362,7 +362,7 @@ fun MyPageProfileHeader(
                     modifier = Modifier
                         .size(24.dp)
                         .clickable {
-                            navController.navigate("user/notice2")
+                            navController.navigate("user/notification")
                         },
                     tint = AppColor.icon_w
                 )

--- a/app/src/main/java/com/example/gravit/main/User/Notice/Notification.kt
+++ b/app/src/main/java/com/example/gravit/main/User/Notice/Notification.kt
@@ -62,7 +62,7 @@ import java.util.Locale
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun Notice2(
+fun Notification(
     navController: NavController,
 ){
     val date = LocalDate.now()
@@ -287,50 +287,51 @@ fun Notice2(
                                                     )
                                                 }
 
-                                                "GO_TO_LEARNING" -> {
-                                                    if (notification.targetId == null)
-                                                        navController.navigate("chapter")
-                                                    else navController.navigate("")
-                                                }
+                                                        "GO_TO_LEARNING" -> {
+                                                            if (notification.targetId == null)
+                                                                navController.navigate("chapter")
+                                                            else navController.navigate("lessonList/${notification.targetId}")
+                                                        }
 
-                                                "GO_TO_NOTICE" -> {
-                                                    navController.navigate("")
-                                                }
+                                                        "GO_TO_NOTICE" -> {
+                                                            navController.navigate("user/notice/detail/${notification.targetId}")
+                                                        }
 
-                                                "UNFOLLOW" -> {
-                                                    notificationVM.toggleFollow(
-                                                        notification.targetId ?: 0,
-                                                        notification.actionType
-                                                    )
-                                                }
+                                                        "UNFOLLOW" -> {
+                                                            notificationVM.toggleFollow(
+                                                                notification.targetId ?: 0,
+                                                                notification.actionType
+                                                            )
+                                                        }
 
-                                                "CONGRATULATE" -> {
-                                                    congratulateVM.congratulate(
-                                                        notification.targetId ?: 0
-                                                    )
-                                                }
+                                                        "CONGRATULATE" -> {
+                                                            congratulateVM.congratulate(
+                                                                notification.targetId ?: 0
+                                                            )
+                                                        }
 
-                                                "GO_TO_INQUIRY" -> {
-                                                    navController.navigate("")
-                                                }
+                                                        "GO_TO_INQUIRY" -> {
+                                                            navController.navigate("inquiry")
+                                                        }
 
-                                                else -> Unit
-                                            }
-                                        },
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(32.dp),
-                                        style = AppTypography.Label2,
-                                        color = if (notification.actionType == "UNFOLLOW") AppColor.CTA else AppColor.CTA_text,
-                                        state = if (notification.actionType == "UNFOLLOW") InlineButtonState.Stroke_Color else InlineButtonState.Default
-                                    )
+                                                        else -> Unit
+                                                    }
+                                                },
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .height(32.dp),
+                                                style = AppTypography.Label2,
+                                                color = if (notification.actionType == "UNFOLLOW") AppColor.CTA else AppColor.CTA_text,
+                                                state = if (notification.actionType == "UNFOLLOW") InlineButtonState.Stroke_Color else InlineButtonState.Default
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-        }
+
         if(isLoading){
             Box(
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/gravit/main/User/Setting/Setting.kt
+++ b/app/src/main/java/com/example/gravit/main/User/Setting/Setting.kt
@@ -35,6 +35,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.gravit.ui.theme.AppColor
 import com.example.gravit.ui.theme.AppTypography
+import com.google.androidbrowserhelper.trusted.NotificationUtils.areNotificationsEnabled
 import com.inuappcenter.gravit.api.RetrofitInstance
 import com.inuappcenter.gravit.error.isDeletionPending
 import com.inuappcenter.gravit.main.ConfirmBottomSheet
@@ -147,10 +148,8 @@ fun Setting(
                             color = AppColor.text3
                         )
                         RowNavigableItem("내 정보", { navController.navigate("user/account") })
-                        RowNavigableItem("공지사항", {})
-                        RowNavigableItem(
-                            "개인정보 처리 방침",
-                            { navController.navigate("user/privacypolicy") })
+                        RowNavigableItem("공지사항", { navController.navigate("user/notice")})
+                        RowNavigableItem("개인정보 처리 방침", { navController.navigate("user/privacypolicy") })
                     }
                 }
                 Box(
@@ -169,7 +168,7 @@ fun Setting(
                             style = AppTypography.Label2,
                             color = AppColor.text3
                         )
-                        RowNavigableItem("문의하기", { navController.navigate("user/support") })
+                        RowNavigableItem("문의하기", { navController.navigate("inquiry") })
                         RowNavigableItem("로그아웃", { logoutVM.logout { onLogout() } })
                         RowNavigableItem("탈퇴하기", { showDeleteSheet = true })
                     }

--- a/app/src/main/java/com/example/gravit/main/User/Setting/Setting.kt
+++ b/app/src/main/java/com/example/gravit/main/User/Setting/Setting.kt
@@ -35,7 +35,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.gravit.ui.theme.AppColor
 import com.example.gravit.ui.theme.AppTypography
-import com.google.androidbrowserhelper.trusted.NotificationUtils.areNotificationsEnabled
 import com.inuappcenter.gravit.api.RetrofitInstance
 import com.inuappcenter.gravit.error.isDeletionPending
 import com.inuappcenter.gravit.main.ConfirmBottomSheet

--- a/app/src/main/java/com/example/gravit/navigation/MainScreen.kt
+++ b/app/src/main/java/com/example/gravit/navigation/MainScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import com.example.gravit.main.User.Inquiry.Inquiry
-import com.example.gravit.main.User.Notice.Notice2
+import com.example.gravit.main.User.Notice.Notification
 import com.inuappcenter.gravit.main.User.MyPage
 
 
@@ -112,19 +112,14 @@ fun MainScreen(rootNavController: NavController) {
                 }
 
                 composable(
-                    route = "lessonList/{unitId}/{unitTitle}",
-                    arguments = listOf(
-                        navArgument("unitId") { type = NavType.IntType },
-                        navArgument("unitTitle") { type = NavType.StringType }
-                    )
+                    route = "lessonList/{unitId}",
+                    arguments = listOf(navArgument("unitId") { type = NavType.IntType },)
                 ) { backStackEntry ->
                     val unitId = backStackEntry.arguments!!.getInt("unitId")
-                    val unitTitle = backStackEntry.arguments!!.getString("unitTitle").orEmpty()
                     LessonList(
                         navController = innerNavController,
                         onSessionExpired = goToLoginChoice,
-                        unitId = unitId,
-                        unitTitle = unitTitle
+                        unitId = unitId
                     )
                 }
 
@@ -203,11 +198,11 @@ fun MainScreen(rootNavController: NavController) {
                 // account
                 composable("user/account") { Account(innerNavController) }
 
-                composable("user/support") { Inquiry(innerNavController, goToLoginChoice) }
+                composable("inquiry") { Inquiry(innerNavController, goToLoginChoice) }
 
                 // notice
                 composable("user/notice") { Notice(innerNavController) }
-                composable("user/notice2") { Notice2(innerNavController) }
+                composable("user/notification") { Notification(innerNavController) }
                 composable(
                     route = "user/notice/detail/{noticeId}",
                     arguments = listOf(


### PR DESCRIPTION
## 작업 내용
notification 경로 설정
- actionType이 GO_TO_INQUIRY, GO_TO_LEARNING, GO_TO_NOTICE인 경우 알림의 targetId에 맞는 화면으로 이동하도록 네비게이션 경로 설정
- GO_TO_LEARNING의 경우 targetId가 null이 아닐 경우만 이동하도록 처리

MainScreen 수정
- 기존 API에서는 LessonList 화면에 필요한 unitTitle을 제공하지 않아 이전 화면에서 네비게이션 인자로 전달받아 사용하고 있었음
   Notification API에서도 unitTitle을 제공하지 않아 알림을 통해 LessonList 화면으로 직접 이동할 수 없었음
-> API에서 unitTitle을 제공하도록 변경됨에 따라 기존 네비게이션 인자 전달 로직을 제거하고 route 수정

## 관련 이슈

close #86 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 단원 수업 목록의 제목이 최신 단원 정보와 일치하도록 표시됩니다.
  * 알림, 공지사항, 문의하기 메뉴의 이동 경로가 정리되어 해당 화면으로 정상 이동합니다.
  * 수업 목록 및 사용자 메뉴 탐색 흐름이 간소화되었습니다.

* **버그 수정**
  * 잘못된 알림·문의 화면으로 이동하던 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->