### PR TITLE
feat: skeleton UI

### DIFF
--- a/app/src/main/java/com/example/gravit/main/Home/HomeScreen.kt
+++ b/app/src/main/java/com/example/gravit/main/Home/HomeScreen.kt
@@ -118,12 +118,7 @@ fun HomeScreen(
 
     when (ui) {
         HomeViewModel.UiState.Loading -> {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
+            HomeSkeletonUI()
         }
 
         is HomeViewModel.UiState.Success -> {

--- a/app/src/main/java/com/example/gravit/main/Home/HomeSkeleton.kt
+++ b/app/src/main/java/com/example/gravit/main/Home/HomeSkeleton.kt
@@ -1,0 +1,238 @@
+package com.inuappcenter.gravit.main.Home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.inuappcenter.gravit.share.skeleton.SkeletonBox
+import com.inuappcenter.gravit.share.skeleton.SkeletonText
+import com.example.gravit.ui.theme.AppColor
+import com.inuappcenter.gravit.R
+
+@Composable
+fun HomeSkeletonUI() {
+
+    LazyColumn(
+        Modifier
+            .fillMaxSize()
+            .background(AppColor.bg2)
+    ) {
+
+        item {
+
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(AppColor.bg2)
+            ) {
+
+                Image(
+                    painter = painterResource(R.drawable.main_back),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxWidth(),
+                    contentScale = ContentScale.FillWidth
+                )
+
+                Column(
+                    Modifier
+                        .statusBarsPadding()
+                        .padding(16.dp)
+                ) {
+                    Row {
+
+                        Box(
+                            Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(Color.White)
+                        )
+
+                        Spacer(Modifier.width(10.dp))
+
+                        SkeletonBox(
+                            Modifier
+                                .height(18.dp)
+                                .width(40.dp)
+                        )
+
+                        Spacer(Modifier.width(24.dp))
+
+                        Box(
+                            Modifier
+                                .size(36.dp)
+                                .clip(CircleShape)
+                                .background(Color.White)
+                        )
+
+                        Spacer(Modifier.width(10.dp))
+
+                        SkeletonBox(
+                            Modifier
+                                .height(18.dp)
+                                .width(70.dp)
+                        )
+                    }
+
+                    Spacer(Modifier.height(90.dp))
+
+                    Box(
+                        Modifier
+                            .height(30.dp)
+                            .fillMaxWidth(.6f)
+                    )
+
+
+                    Spacer(Modifier.height(10.dp))
+
+                    Box(
+                        Modifier
+                            .height(15.dp)
+                            .fillMaxWidth(.5f)
+                    )
+
+                    Spacer(Modifier.height(20.dp))
+
+                    SkeletonStreakCard()
+
+                    Spacer(Modifier.height(16.dp))
+
+                    Row {
+
+                        SkeletonMissionCard(
+                            Modifier.weight(1f)
+                        )
+
+                        Spacer(Modifier.width(16.dp))
+
+                        SkeletonMissionCard(
+                            Modifier.weight(1f)
+                        )
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+
+                    SkeletonPreviousCard()
+
+                    Spacer(Modifier.height(20.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SkeletonStreakCard() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(AppColor.bg0)
+            .padding(16.dp)
+    ) {
+        SkeletonText(
+            width = 80.dp
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SkeletonText(
+            width = 100.dp,
+            height = 30.dp
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            repeat(7) {
+                SkeletonBox(
+                    modifier = Modifier.size(32.dp),
+                    shape = RoundedCornerShape(6.dp)
+                )
+            }
+        }
+    }
+}
+@Composable
+private fun SkeletonMissionCard(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .height(156.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(AppColor.bg0)
+            .padding(16.dp)
+    ) {
+        SkeletonText(
+            width = 60.dp
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        SkeletonBox(
+            modifier = Modifier
+                .height(22.dp)
+                .fillMaxWidth(0.8f)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SkeletonText(width = 70.dp)
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        SkeletonBox(
+            modifier = Modifier
+                .height(8.dp)
+                .fillMaxWidth(),
+            shape = RoundedCornerShape(4.dp)
+        )
+    }
+}
+@Composable
+private fun SkeletonPreviousCard() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(AppColor.bg0)
+            .padding(16.dp)
+    ) {
+        SkeletonText(
+            width = 120.dp,
+            height = 16.dp
+        )
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        SkeletonBox(
+            modifier = Modifier
+                .height(8.dp)
+                .fillMaxWidth(),
+            shape = RoundedCornerShape(4.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/gravit/main/Study/Chapter/ChapterSkeleton.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Chapter/ChapterSkeleton.kt
@@ -1,0 +1,85 @@
+package com.inuappcenter.gravit.main.Study.Chapter
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.gravit.share.skeleton.SkeletonBox
+
+@Composable
+fun ChapterSkeletonUI() {
+
+    Column(
+        modifier = Modifier
+            .background(Color(0xFFF2F2F2))
+            .padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 16.dp
+            )
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        repeat(4) {
+            Row(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                ChapterSkeletonCard(
+                    modifier = Modifier
+                        .weight(1f)
+                        .aspectRatio(160f / 166f)
+                )
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                ChapterSkeletonCard(
+                    modifier = Modifier
+                        .weight(1f)
+                        .aspectRatio(160f / 166f)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}
+
+@Composable
+private fun ChapterSkeletonCard(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color.White)
+            .padding(16.dp)
+    ) {
+        SkeletonBox(
+            modifier = Modifier
+                .width(60.dp)
+                .height(25.dp)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SkeletonBox(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/gravit/main/Study/Chapter/LearningPage.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Chapter/LearningPage.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -125,31 +124,18 @@ fun Learning(
             else -> Unit
         }
     }
-
-    when (ui) {
-        ChapterViewModel.UiState.Loading -> {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-        }
-
-        is ChapterViewModel.UiState.Success -> {
-            val chapters = (ui as ChapterViewModel.UiState.Success).data
-            LearningUI(
-                navController = navController,
-                chapters = chapters,
-                selectedTab = selectedTab,
-                onTabSelected = { selectedTab = it }
-            )
-        }
-        else -> Unit
-    }
+    LearningUI(
+        navController = navController,
+        uiState = ui,
+        selectedTab = selectedTab,
+        onTabSelected = { selectedTab = it }
+    )
 }
 
 @Composable
 private fun LearningUI(
     navController: NavController,
-    chapters: List<ChapterPageResponse>,
+    uiState: ChapterViewModel.UiState,
     selectedTab: LearningTab,
     onTabSelected: (LearningTab) -> Unit
 ){
@@ -193,10 +179,20 @@ private fun LearningUI(
             )
             when (selectedTab) {
                 LearningTab.Chapter -> {
-                    ChapterUI(
-                        navController = navController,
-                        chapters = chapters
-                    )
+                    when (uiState) {
+                        ChapterViewModel.UiState.Loading -> {
+                            ChapterSkeletonUI()
+                        }
+
+                        is ChapterViewModel.UiState.Success -> {
+                            ChapterUI(
+                                navController = navController,
+                                chapters = uiState.data
+                            )
+                        }
+
+                        else -> Unit
+                    }
                 }
 
                 LearningTab.AI -> {

--- a/app/src/main/java/com/example/gravit/main/Study/Lesson/LessonList.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Lesson/LessonList.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -108,9 +107,7 @@ fun LessonList(
 
     when (ui) {
         LessonListVM.UiState.Loading -> {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
+            LessonListSkeletonUI(navController)
         }
 
         is LessonListVM.UiState.Success -> {

--- a/app/src/main/java/com/example/gravit/main/Study/Lesson/LessonListSkeleton.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Lesson/LessonListSkeleton.kt
@@ -1,0 +1,187 @@
+package com.inuappcenter.gravit.main.Study.Lesson
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.inuappcenter.gravit.share.skeleton.SkeletonBox
+import com.inuappcenter.gravit.share.skeleton.TopBarSkeleton
+import com.example.gravit.ui.theme.AppColor
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.inuappcenter.gravit.R
+
+@Composable
+fun LessonListSkeletonUI(
+    navController: NavController
+) {
+    val systemUiController = rememberSystemUiController()
+
+    SideEffect {
+        systemUiController.setStatusBarColor(
+            color = Color.Transparent,
+            darkIcons = true
+        )
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppColor.bg0)
+    ) {
+        TopBarSkeleton(
+            navController = navController
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .background(AppColor.bg1)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.unitlesson_back),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = 20.dp
+                    )
+            ) {
+                SkeletonBox(
+                    modifier = Modifier
+                        .width(140.dp)
+                        .height(28.dp)
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                SkeletonBox(
+                    modifier = Modifier
+                        .fillMaxWidth(0.75f)
+                        .height(12.dp)
+                )
+
+                Spacer(Modifier.height(12.dp))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(67.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(AppColor.bg0),
+                    contentAlignment = Alignment.CenterStart
+                ){
+                    SkeletonBox(
+                        Modifier
+                            .fillMaxWidth(.5f)
+                            .height(30.dp)
+                            .padding(start = 16.dp)
+                    )
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth()
+                ){
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(156.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(AppColor.bg0)
+                            .padding(horizontal = 16.dp, vertical = 12.dp)
+                    ){
+                        SkeletonBox(
+                            Modifier
+                                .fillMaxWidth(.5f)
+                                .height(20.dp)
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        SkeletonBox(
+                            Modifier
+                                .fillMaxWidth(.8f)
+                                .height(10.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(156.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(AppColor.bg0)
+                            .padding(horizontal = 16.dp, vertical = 12.dp)
+                    ){
+                        SkeletonBox(
+                            Modifier
+                                .fillMaxWidth(.5f)
+                                .height(20.dp)
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        SkeletonBox(
+                            Modifier
+                                .fillMaxWidth(.8f)
+                                .height(10.dp)
+                        )
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+                Box (
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(AppColor.bg0)
+                ) {
+                    LazyColumn(
+                        modifier = Modifier
+                            .padding(vertical = 12.dp, horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        userScrollEnabled = false
+                    ) {
+                        item{
+                            SkeletonBox(
+                                modifier = Modifier
+                                    .fillMaxWidth(fraction = .3f)
+                                    .height(12.dp)
+                            )
+                        }
+                        items(3) {
+                            SkeletonBox(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(59.dp),
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/gravit/main/Study/Unit/UnitList.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Unit/UnitList.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -90,14 +89,7 @@ fun UnitList(
     when (val state = uiState) {
         UnitListVM.UiState.Loading,
         UnitListVM.UiState.Idle -> {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator(color = Color.White)
-            }
+            UnitListSkeletonUI(navController)
         }
 
         UnitListVM.UiState.SessionExpired -> {

--- a/app/src/main/java/com/example/gravit/main/Study/Unit/UnitListSkeleton.kt
+++ b/app/src/main/java/com/example/gravit/main/Study/Unit/UnitListSkeleton.kt
@@ -1,0 +1,144 @@
+package com.inuappcenter.gravit.main.Study.Unit
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.inuappcenter.gravit.share.skeleton.SkeletonBox
+import com.inuappcenter.gravit.share.skeleton.TopBarSkeleton
+import com.example.gravit.ui.theme.AppColor
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.inuappcenter.gravit.R
+
+@Composable
+fun UnitListSkeletonUI(
+    navController: NavController
+) {
+    val systemUiController = rememberSystemUiController()
+
+    SideEffect {
+        systemUiController.setStatusBarColor(
+            color = Color.Transparent,
+            darkIcons = true
+        )
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppColor.bg0)
+    ) {
+        TopBarSkeleton(
+            navController = navController
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .background(AppColor.bg1)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.unitlesson_back),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = 20.dp
+                    )
+            ) {
+                SkeletonBox(
+                    modifier = Modifier
+                        .width(140.dp)
+                        .height(28.dp)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                SkeletonBox(
+                    modifier = Modifier
+                        .fillMaxWidth(0.75f)
+                        .height(12.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(bottom = 40.dp),
+                    userScrollEnabled = false
+                ) {
+                    items(6) {
+                        UnitItemSkeleton()
+                    }
+                }
+            }
+        }
+    }
+}
+@Composable
+private fun UnitItemSkeleton() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(112.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(AppColor.bg0)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            SkeletonBox(
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .height(20.dp)
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            SkeletonBox(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(12.dp)
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            SkeletonBox(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/gravit/main/User/MyPage.kt
+++ b/app/src/main/java/com/example/gravit/main/User/MyPage.kt
@@ -3,6 +3,7 @@ package com.inuappcenter.gravit.main.User
 import android.annotation.SuppressLint
 import android.graphics.BlurMaskFilter
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
@@ -16,8 +17,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,7 +24,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -114,18 +113,24 @@ fun MyPage(
 ) {
     val context = LocalContext.current
     val vm: UserScreenVM = viewModel(factory = UserVMFactory(RetrofitInstance.api, context))
-    MyPageUI(vm, navController)
+    MyPageUI(
+        vm = vm,
+        navController = navController,
+        onSessionExpired = onSessionExpired
+    )
 }
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MyPageUI(
     vm: UserScreenVM,
     navController: NavController,
+    onSessionExpired: () -> Unit
 ) {
 
     var selectedTab by remember { mutableStateOf(MyPageTab.Summary) }
     var showSnackBar by remember { mutableStateOf(false) }
     var snackBarText by remember { mutableStateOf("") }
+    var navigated by remember { mutableStateOf(false) }
 
     val bannerUi by vm.stateBanners.collectAsState()
     val socialUi by vm.stateSocial.collectAsState()
@@ -135,16 +140,6 @@ fun MyPageUI(
     val congratulateUi by vm.stateCongratulate.collectAsState()
     val followUi by vm.stateFollow.collectAsState()
 
-    val isLoading = bannerUi == UserScreenVM.BannersUiState.Loading ||
-                when (selectedTab) {
-                    MyPageTab.Summary -> summaryUi == UserScreenVM.SummaryUiState.Loading
-                    MyPageTab.Learning -> learningUi == UserScreenVM.LearningUiState.Loading
-                    MyPageTab.League -> leagueUi == UserScreenVM.LeagueUiState.Loading
-                    MyPageTab.Social ->
-                        socialUi == UserScreenVM.SocialUiState.Loading ||
-                        followUi == UserScreenVM.FollowUiState.Loading ||
-                        congratulateUi == UserScreenVM.CongratulateUiState.Loading
-                }
     val isSessionExpired = bannerUi == UserScreenVM.BannersUiState.SessionExpired ||
             when (selectedTab) {
                 MyPageTab.Summary -> summaryUi == UserScreenVM.SummaryUiState.SessionExpired
@@ -172,7 +167,17 @@ fun MyPageUI(
 
             }
 
-    var navigated by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        vm.loadBanners()
+        vm.loadSummary()
+        vm.loadLearning()
+        vm.loadLeague()
+    }
+    LaunchedEffect(selectedTab) {
+        if (selectedTab == MyPageTab.Social) {
+            vm.loadSocial()
+        }
+    }
 
     LaunchedEffect(isSessionExpired) {
         if (!isSessionExpired || navigated) return@LaunchedEffect
@@ -188,7 +193,7 @@ fun MyPageUI(
     }
     LaunchedEffect(isNotFound) {
         if (!isNotFound || navigated) return@LaunchedEffect
-
+        navigated = true
         navController.navigate("error/404") {
             popUpTo(
                 navController.currentBackStackEntry?.destination?.id ?: return@navigate
@@ -211,6 +216,7 @@ fun MyPageUI(
             }
 
             UserScreenVM.CongratulateUiState.Success -> {
+                vm.clearCongratulateState()
                 vm.loadSocial()
             }
             else -> Unit
@@ -235,58 +241,31 @@ fun MyPageUI(
             vm.clearLoadMoreError()
         }
     }
-
-    LaunchedEffect(Unit) {
-        vm.loadBanners()
-        vm.loadSummary()
-        vm.loadLearning()
-        vm.loadLeague()
-    }
-    LaunchedEffect(selectedTab) {
-        if (selectedTab == MyPageTab.Social) {
-            vm.loadSocial()
-        }
-    }
-    val banners = (bannerUi as? UserScreenVM.BannersUiState.Success)?.data
-
-    Box(modifier = Modifier.fillMaxSize()) {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(AppColor.bg2)
-                .padding(WindowInsets.statusBars.asPaddingValues()),
-            contentPadding = PaddingValues(bottom = 16.dp)
-        ) {
-            item {
-                MyPageProfileHeader(banners, navController)
-            }
-            item {
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp)
-                ) {
-                    MyPageTabRow(
+    val initialSkeleton = selectedTab == MyPageTab.Summary && (bannerUi == UserScreenVM.BannersUiState.Loading || summaryUi == UserScreenVM.SummaryUiState.Loading)
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        if (initialSkeleton) {
+            MyPageSkeletonUI(navController = navController)
+        } else {
+            when (val state = bannerUi) {
+                is UserScreenVM.BannersUiState.Success -> {
+                    MyPageContent(
+                        banner = state.data,
                         selectedTab = selectedTab,
-                        onTabSelected = { selectedTab = it },
-                        modifier = Modifier.padding(top = 16.dp)
+                        onTabSelected = {
+                            selectedTab = it
+                        },
+                        vm = vm,
+                        navController = navController,
+                        socialUi = socialUi
                     )
-                    Spacer(Modifier.height(16.dp))
-                    when (selectedTab) {
-                        MyPageTab.Summary -> SummaryUI(vm)
-                        MyPageTab.Learning -> LearningTabUI(vm, navController)
-                        MyPageTab.League -> LeagueTabUI(vm)
-                        MyPageTab.Social -> SocialTabUI(navController, vm, banners?.nickname)
-                    }
                 }
+
+                else -> Unit
             }
         }
-        if (isLoading) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-        }
+
         if (showSnackBar) {
             CustomSnackBar(
                 text = snackBarText,
@@ -298,6 +277,55 @@ fun MyPageUI(
             LaunchedEffect(snackBarText) {
                 delay(2000)
                 showSnackBar = false
+            }
+        }
+    }
+}
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+private fun MyPageContent(
+    banner: MyPageBanner,
+    selectedTab: MyPageTab,
+    onTabSelected: (MyPageTab) -> Unit,
+    vm: UserScreenVM,
+    navController: NavController,
+    socialUi: UserScreenVM.SocialUiState
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppColor.bg2)
+            .statusBarsPadding(),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        item {
+            MyPageProfileHeader(
+                banner = banner,
+                navController = navController
+            )
+        }
+
+        item {
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = 16.dp
+                )
+            ) {
+                MyPageTabRow(
+                    selectedTab = selectedTab,
+                    onTabSelected = onTabSelected,
+                    modifier = Modifier.padding(top = 16.dp)
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                MyPageTabContent(
+                    selectedTab = selectedTab,
+                    vm = vm,
+                    navController = navController,
+                    nickname = banner.nickname,
+                    socialUi = socialUi
+                )
             }
         }
     }
@@ -416,6 +444,56 @@ fun ProfileBox(
             style = AppTypography.Caption1,
             color = PrimitiveColor.Gray50
         )
+    }
+}
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+private fun MyPageTabContent(
+    selectedTab: MyPageTab,
+    vm: UserScreenVM,
+    navController: NavController,
+    nickname: String?,
+    socialUi: UserScreenVM.SocialUiState
+) {
+    when (selectedTab) {
+        MyPageTab.Summary -> {
+            SummaryUI(vm)
+        }
+
+        MyPageTab.Learning -> {
+            LearningTabUI(
+                vm = vm,
+                navController = navController
+            )
+        }
+
+        MyPageTab.League -> {
+            LeagueTabUI(vm)
+        }
+
+        MyPageTab.Social -> {
+            when (socialUi) {
+                UserScreenVM.SocialUiState.Loading -> {
+                   Box(
+                       modifier = Modifier.fillMaxSize(),
+                       contentAlignment = Alignment.Center
+                   ){
+                       CircularProgressIndicator()
+                   }
+                }
+
+                is UserScreenVM.SocialUiState.Success -> {
+                    SocialTabUI(
+                        navController = navController,
+                        vm = vm,
+                        nickname = nickname
+                    )
+                }
+                else -> {
+                    Log.d("SOCIAL", socialUi.toString())
+                }
+            }
+        }
     }
 }
 @Composable
@@ -1449,9 +1527,6 @@ fun SocialTabUI(
     nickname: String?
 ) {
     val ui by vm.stateSocial.collectAsState()
-    LaunchedEffect(Unit) {
-        vm.loadSocial()
-    }
     val social = (ui as? UserScreenVM.SocialUiState.Success)?.data
     val listState = rememberLazyListState()
 

--- a/app/src/main/java/com/example/gravit/main/User/MyPageSkeleton.kt
+++ b/app/src/main/java/com/example/gravit/main/User/MyPageSkeleton.kt
@@ -1,0 +1,199 @@
+package com.inuappcenter.gravit.main.User
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.inuappcenter.gravit.share.skeleton.SkeletonBox
+import com.example.gravit.ui.theme.AppColor
+import com.inuappcenter.gravit.R
+
+@Composable
+fun MyPageSkeletonUI(
+    navController: NavController,
+){
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppColor.bg2)
+            .statusBarsPadding(),
+        contentPadding = PaddingValues(bottom = 16.dp),
+        userScrollEnabled = false
+    ) {
+        item {
+            Box (
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(195.dp)
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.mypage_bg),
+                    contentDescription = "main back",
+                    modifier = Modifier.fillMaxWidth(),
+                    contentScale = ContentScale.Crop,
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(vertical = 24.dp, horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Row(modifier = Modifier.height(70.dp)) {
+                        SkeletonBox(
+                            modifier = Modifier.size(70.dp),
+                            shape = RoundedCornerShape(100f)
+                        )
+                        Spacer(Modifier.width(12.dp))
+
+                        Column(modifier = Modifier.padding(vertical = 7.5.dp)) {
+                            Spacer(Modifier.height(8.dp))
+                            SkeletonBox(
+                                Modifier.size(60.dp, 20.dp)
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            SkeletonBox(
+                                Modifier.size(80.dp, 20.dp)
+                            )
+                        }
+                        Spacer(Modifier.weight(1f))
+                        Icon(
+                            painter = painterResource(id = R.drawable.bell),
+                            contentDescription = "bell",
+                            modifier = Modifier
+                                .size(24.dp)
+                                .clickable {
+                                    navController.navigate("user/notification")
+                                },
+                            tint = AppColor.icon_w
+                        )
+                        Spacer(Modifier.width(16.dp))
+                        Icon(
+                            painter = painterResource(id = R.drawable.setting),
+                            contentDescription = "setting",
+                            modifier = Modifier
+                                .size(24.dp)
+                                .clickable {
+                                    navController.navigate("user/setting")
+                                },
+                            tint = AppColor.icon_w
+
+                        )
+                    }
+                    Spacer(Modifier.weight(1f))
+                    SkeletonBox(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(37.dp),
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                }
+            }
+        }
+        item {
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) {
+                Spacer(Modifier.height(16.dp))
+                SkeletonBox(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(44.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+                SummaryTabSkeletonUI()
+            }
+        }
+    }
+
+}
+
+@Composable
+fun SummaryTabSkeletonUI(){
+    Column {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(AppColor.bg0)
+                .padding(16.dp),
+        ) {
+            Column {
+                SkeletonBox(
+                    modifier = Modifier
+                        .width(140.dp)
+                        .height(40.dp)
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                SkeletonBox(
+                    modifier = Modifier
+                        .fillMaxWidth(0.75f)
+                        .height(20.dp)
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                SkeletonBox(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(7.dp)
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(AppColor.bg0)
+                .padding(16.dp),
+        ) {
+            Column {
+                SkeletonBox(
+                    modifier = Modifier
+                        .width(140.dp)
+                        .height(40.dp)
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                SkeletonBox(
+                    modifier = Modifier
+                        .fillMaxWidth(0.75f)
+                        .height(20.dp)
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                SkeletonBox(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(7.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/gravit/main/User/MyPageVM.kt
+++ b/app/src/main/java/com/example/gravit/main/User/MyPageVM.kt
@@ -418,6 +418,9 @@ class UserScreenVM (
             )
         )
     }
+    fun clearCongratulateState() {
+        _stateCongratulate.value = CongratulateUiState.Idle
+    }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/example/gravit/share/skeleton/SkeletonBox.kt
+++ b/app/src/main/java/com/example/gravit/share/skeleton/SkeletonBox.kt
@@ -1,0 +1,119 @@
+package com.inuappcenter.gravit.share.skeleton
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.gravit.ui.theme.AppColor
+import com.inuappcenter.gravit.R
+
+@Composable
+fun SkeletonBox(
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(4.dp)
+) {
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .shimmer()
+    )
+}
+@Composable
+fun SkeletonCircle(
+    modifier: Modifier = Modifier
+) {
+    SkeletonBox(
+        modifier = modifier,
+        shape = CircleShape
+    )
+}
+@Composable
+fun SkeletonText(
+    modifier: Modifier = Modifier,
+    width: Dp,
+    height: Dp = 14.dp
+) {
+    SkeletonBox(
+        modifier = modifier
+            .width(width)
+            .height(height),
+        shape = RoundedCornerShape(4.dp)
+    )
+}
+
+@Composable
+fun TopBarSkeleton(
+    navController: NavController
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(WindowInsets.statusBars.asPaddingValues())
+            .height(48.dp)
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.chevron_left),
+            contentDescription = "뒤로가기",
+            tint = AppColor.icon_default,
+            modifier = Modifier.clickable{navController.popBackStack()}
+        )
+
+    }
+}
+@Composable
+fun Modifier.shimmer(): Modifier {
+    val transition = rememberInfiniteTransition(label = "")
+
+    val translateAnim = transition.animateFloat(
+        initialValue = -300f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1200,
+                easing = LinearEasing
+            )
+        ),
+        label = ""
+    )
+
+    val brush = Brush.linearGradient(
+        colors = listOf(
+            Color(0xFFE5E5E5),
+            Color(0xFFF5F5F5),
+            Color(0xFFE5E5E5)
+        ),
+        start = Offset(translateAnim.value, 0f),
+        end = Offset(translateAnim.value + 300f, 300f)
+    )
+
+    return this.background(brush)
+}


### PR DESCRIPTION
## 작업 내용
- 공용 스켈레톤 ui 생성
- 스켈레톤 ui 적용(홈, 챕터, 유닛, 레슨, 마이페이지)
- 마이페이지 소셜탭에서 스켈레톤 ui가 중복으로 나오는 문제 발생
    - 축하하기 기능이 초기화되지 않아서 발생한 것으로 초기화 함수 생성

## 관련 이슈

close #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 홈, 챕터, 레슨, 단위, 마이페이지의 로딩 화면에 스켈레톤 UI를 추가했습니다.
  - 로딩 중 콘텐츠 구조를 미리 보여주고 shimmer 애니메이션을 제공합니다.
  - 마이페이지의 탭별 로딩 및 세션 만료 처리를 개선했습니다.

- **버그 수정**
  - 로딩 완료 후 화면 전환과 상태 초기화 처리를 안정화했습니다.
  - 세션 만료 시 중복 이동을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->